### PR TITLE
Use environment STOREFRONT_ASSETS_PORT for hot reload server

### DIFF
--- a/changelog/_unreleased/2021-08-09-use-environment-storefront_assets_port-for-hot-reload.md
+++ b/changelog/_unreleased/2021-08-09-use-environment-storefront_assets_port-for-hot-reload.md
@@ -1,6 +1,6 @@
 ---
 title: Use environment STOREFRONT_ASSETS_PORT for hot reload
-issue: noticket
+issue: NEXT-17813
 author: Manuel Selbach
 author_email: m.selbach@kellerkinder.de 
 author_github: manuelselbach

--- a/changelog/_unreleased/2021-08-09-use-environment-storefront_assets_port-for-hot-reload.md
+++ b/changelog/_unreleased/2021-08-09-use-environment-storefront_assets_port-for-hot-reload.md
@@ -1,0 +1,10 @@
+---
+title: Use environment STOREFRONT_ASSETS_PORT for hot reload
+issue: noticket
+author: Manuel Selbach
+author_email: m.selbach@kellerkinder.de 
+author_github: manuelselbach
+---
+# Core
+
+* With this change the environment variable STOREFRONT_ASSETS_PORT is also used for the hot reload server and it falls back to the static value `9999` like it is done everywhere else in the webpack configuration, to be able to actually use a custom port.

--- a/src/Storefront/Resources/app/storefront/webpack.config.js
+++ b/src/Storefront/Resources/app/storefront/webpack.config.js
@@ -57,7 +57,7 @@ let webpackConfig = {
                 hot: true,
                 compress: false,
                 disableHostCheck: true,
-                port: 9999,
+                port: parseInt(process.env.STOREFRONT_ASSETS_PORT || 9999),
                 host: '127.0.0.1',
                 clientLogLevel: 'warning',
                 headers: {

--- a/src/Storefront/Resources/app/storefront/webpack.config.js
+++ b/src/Storefront/Resources/app/storefront/webpack.config.js
@@ -57,7 +57,7 @@ let webpackConfig = {
                 hot: true,
                 compress: false,
                 disableHostCheck: true,
-                port: parseInt(process.env.STOREFRONT_ASSETS_PORT || 9999),
+                port: parseInt(process.env.STOREFRONT_ASSETS_PORT || 9999, 10),
                 host: '127.0.0.1',
                 clientLogLevel: 'warning',
                 headers: {


### PR DESCRIPTION


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

The environment variable STOREFRONT_ASSETS_PORT should be used to
be able to have a custom port specified. Unfortunately it is not for the hot
reload server and the static value `9999` is placed.

### 2. What does this change do, exactly?

With this change the environment variable STOREFRONT_ASSETS_PORT is
also used for the hot reload server and it falls back to the static value like it
is done everywhere else in the webpack configuration, to be able to actually
use a custom port.

### 3. Describe each step to reproduce the issue or behavior.

- Specify a custom port for the environment variable STOREFRONT_ASSETS_PORT
- Start the storefront watch task
- The custom port will not work

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
